### PR TITLE
Move flushing into write mutex

### DIFF
--- a/lib/ccrpc/rpc_connection.rb
+++ b/lib/ccrpc/rpc_connection.rb
@@ -249,8 +249,8 @@ class RpcConnection
       to_send << Escape.escape(func.to_s) << "\a#{id}"
       to_send << "\a#{recv_id}" if recv_id
       @write_io.write(to_send << "\n")
+      @write_io.flush
     end
-    @write_io.flush
     after_write
   end
 
@@ -267,8 +267,8 @@ class RpcConnection
       end
       to_send << "\a#{id}" if id
       @write_io.write(to_send << "\n")
+      @write_io.flush
     end
-    @write_io.flush
     after_write
   end
 


### PR DESCRIPTION
For some reason communication hangs when transmission runs over popen IOs. This happens particular often on Windows in test_call_back_popen like so:
```
D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:117:in `gets': Interrupt
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:117:in `block in initialize'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:273:in `each'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:273:in `each'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:273:in `receive_answers'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:207:in `block (3 levels) in call_intern'
	from <internal:kernel>:187:in `loop'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:185:in `block (2 levels) in call_intern'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:184:in `synchronize'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:184:in `block in call_intern'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:131:in `dont_lazy'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:183:in `call_intern'
	from D:/a/ccrpc/ccrpc/lib/ccrpc/rpc_connection.rb:169:in `call'
	from D:/a/_temp/rpc20241016-6076-5dq5to:33:in `<main>'

Tasks: TOP => test
(See full trace by running task with --trace)
TestRpcConnection#test_call_back_popen =
```
But it happened at least once on Ubuntu with ruby-2.7.

Moving the flush inside the write_mutex protected area seems to fix this issue.